### PR TITLE
Add trace logging to OAuth Client CIMD requests

### DIFF
--- a/.changeset/clever-hands-occur.md
+++ b/.changeset/clever-hands-occur.md
@@ -1,0 +1,5 @@
+---
+'@thisismissem/adonisjs-atproto-oauth': patch
+---
+
+Add trace logging to OAuth Client CIMD requests

--- a/src/client.ts
+++ b/src/client.ts
@@ -142,6 +142,7 @@ export class OAuthClient {
       }
 
       if (!clientId.startsWith(publicUrl)) {
+        this.logger.trace(`Fetching OAuth Client Metadata: ${clientId}`)
         this.#metadata = await NodeOAuthClient.fetchMetadata({
           clientId: oauthClientIdDiscoverableSchema.parse(clientId),
         })
@@ -150,6 +151,7 @@ export class OAuthClient {
       }
     } else {
       if (clientId !== this.defaultClientId()) {
+        this.logger.trace(`Fetching OAuth Client Metadata: ${clientId}`)
         this.#metadata = await NodeOAuthClient.fetchMetadata({
           clientId: oauthClientIdDiscoverableSchema.parse(clientId),
         })
@@ -159,6 +161,8 @@ export class OAuthClient {
             'OAuth client metadata contains jwks or jwks_uri properties, these are unsupported by CIMD Service'
           )
         }
+
+        this.logger.trace(`Registering OAuth Client with cimd-service`)
         this.#metadata = await this.registerClient(compiledMetadata)
       }
     }


### PR DESCRIPTION
This improves visibility in the logs for when something is going wrong with cimd-service