### PR TITLE
Implement vine.js rules for validating AT Protocol string formats

### DIFF
--- a/.changeset/tidy-pandas-marry.md
+++ b/.changeset/tidy-pandas-marry.md
@@ -1,0 +1,17 @@
+---
+'@thisismissem/adonisjs-atproto-oauth': minor
+---
+
+Add vine.js rules for validating various AT Protocol string formats
+
+Implementation of custom vine.js rules for validating various AT Protocol [string format](https://atproto.com/specs/lexicon#string-formats):
+
+- `vine.atproto.identifier()`
+- `vine.atproto.did()`
+- `vine.atproto.handle()`
+- `vine.atproto.service()`
+- `vine.atproto.atUri()`
+- `vine.atproto.datetime()`
+- `vine.atproto.language()`
+
+The only rule that isn't a typical [string format](https://atproto.com/specs/lexicon#string-formats) from AT Protocol is `vine.atproto.service()` which is used for validating OAuth service identifiers, which are essentially just URLs without an components after the hostname. You'd use this rule for validating an OAuth sign up request.

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@atproto/jwk-jose": "^0.1.11",
     "@atproto/lex": "^0.0.11",
     "@atproto/oauth-client-node": "^0.3.15",
+    "@atproto/syntax": "^0.4.3",
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@japa/assert": "^4.2.0",
@@ -81,6 +82,7 @@
     "@swc/core": "^1.6.3",
     "@types/luxon": "^3.7.1",
     "@types/node": "^22.19.3",
+    "@vinejs/vine": "^4.2.0",
     "c8": "^10.1.2",
     "copyfiles": "^2.4.1",
     "del-cli": "^7.0.0",
@@ -100,6 +102,7 @@
     "@atproto/jwk-jose": "^0.1.11",
     "@atproto/lex": "^0.0.11",
     "@atproto/oauth-client-node": "^0.3.15",
+    "@vinejs/vine": "^4.2.0",
     "luxon": "^3.7.2"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,16 +17,16 @@ importers:
         version: 7.8.2(typescript@5.9.3)
       '@adonisjs/auth':
         specifier: ^9.5.1
-        version: 9.5.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(luxon@3.7.2))
+        version: 9.5.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@vinejs/vine@4.2.0)(luxon@3.7.2))
       '@adonisjs/core':
         specifier: ^6.12.0
-        version: 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))
+        version: 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)
       '@adonisjs/eslint-config':
         specifier: 2.1.2
         version: 2.1.2(eslint@9.39.2)(prettier@3.7.4)(typescript@5.9.3)
       '@adonisjs/lucid':
         specifier: ^21.8.2
-        version: 21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(luxon@3.7.2)
+        version: 21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@vinejs/vine@4.2.0)(luxon@3.7.2)
       '@adonisjs/prettier-config':
         specifier: ^1.4.0
         version: 1.4.5
@@ -48,6 +48,9 @@ importers:
       '@atproto/oauth-client-node':
         specifier: ^0.3.15
         version: 0.3.15
+      '@atproto/syntax':
+        specifier: ^0.4.3
+        version: 0.4.3
       '@changesets/changelog-github':
         specifier: ^0.5.2
         version: 0.5.2
@@ -69,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
+      '@vinejs/vine':
+        specifier: ^4.2.0
+        version: 4.2.0
       c8:
         specifier: ^10.1.2
         version: 10.1.3
@@ -405,6 +411,9 @@ packages:
 
   '@atproto/syntax@0.4.2':
     resolution: {integrity: sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA==}
+
+  '@atproto/syntax@0.4.3':
+    resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
 
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
@@ -933,6 +942,9 @@ packages:
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stylistic/eslint-plugin@5.6.1':
     resolution: {integrity: sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1075,6 +1087,9 @@ packages:
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
   '@typescript-eslint/eslint-plugin@8.50.0':
     resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1133,6 +1148,14 @@ packages:
   '@typescript-eslint/visitor-keys@8.50.0':
     resolution: {integrity: sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vinejs/compiler@4.1.2':
+    resolution: {integrity: sha512-Cg5EE6wft/kYlxDti577WVCIXNb0FFsXdR+aphz1E+KXoc0pLRa4HbZydHu0bCDW5iPuRZujctmRpzEoA7/Nag==}
+    engines: {node: '>=18.0.0'}
+
+  '@vinejs/vine@4.2.0':
+    resolution: {integrity: sha512-pb6iC9jX7w42nEvKUUWOWcnF1qZDPvmEFjgHCO1hwbO9nOrFw6e3JpYiZNoJGloywXeoE1FgC4JkKk9fdNSdow==}
+    engines: {node: '>=18.16.0'}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1347,6 +1370,10 @@ packages:
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  camelcase@9.0.0:
+    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
+    engines: {node: '>=20'}
 
   caniuse-lite@1.0.30001761:
     resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
@@ -1585,6 +1612,9 @@ packages:
   date-fns@1.30.1:
     resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1658,6 +1688,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -2747,6 +2780,10 @@ packages:
     resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   np@10.2.0:
     resolution: {integrity: sha512-7Pwk8qcsks2c9ETS35aeJSON6uJAbOsx7TwTFzZNUGgH4djT+Yt/p9S7PZuqH5pkcpNUhasne3cDRBzaUtvetg==}
     engines: {bun: '>=1', git: '>=2.11.0', node: '>=18', npm: '>=9', pnpm: '>=8', yarn: '>=1.7.0'}
@@ -3734,6 +3771,10 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  validator@13.15.26:
+    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
+    engines: {node: '>= 0.10'}
+
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
@@ -3906,14 +3947,14 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@adonisjs/auth@9.5.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(luxon@3.7.2))':
+  '@adonisjs/auth@9.5.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@vinejs/vine@4.2.0)(luxon@3.7.2))':
     dependencies:
-      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))
-      '@adonisjs/presets': 2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))
+      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)
+      '@adonisjs/presets': 2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))
       '@poppinss/utils': 6.10.1
       basic-auth: 2.0.1
     optionalDependencies:
-      '@adonisjs/lucid': 21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(luxon@3.7.2)
+      '@adonisjs/lucid': 21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@vinejs/vine@4.2.0)(luxon@3.7.2)
     transitivePeerDependencies:
       - '@adonisjs/assembler'
 
@@ -3938,7 +3979,7 @@ snapshots:
     dependencies:
       '@poppinss/utils': 6.10.1
 
-  '@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))':
+  '@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)':
     dependencies:
       '@adonisjs/ace': 13.4.0
       '@adonisjs/application': 8.4.2(@adonisjs/config@5.0.3)(@adonisjs/fold@10.2.1)
@@ -3970,6 +4011,7 @@ snapshots:
       youch-terminal: 2.2.3
     optionalDependencies:
       '@adonisjs/assembler': 7.8.2(typescript@5.9.3)
+      '@vinejs/vine': 4.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4067,10 +4109,10 @@ snapshots:
       abstract-logging: 2.0.1
       pino: 10.1.0
 
-  '@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))(luxon@3.7.2)':
+  '@adonisjs/lucid@21.8.2(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))(@vinejs/vine@4.2.0)(luxon@3.7.2)':
     dependencies:
-      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))
-      '@adonisjs/presets': 2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))
+      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)
+      '@adonisjs/presets': 2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))
       '@faker-js/faker': 9.9.0
       '@poppinss/hooks': 7.3.0
       '@poppinss/macroable': 1.1.0
@@ -4086,6 +4128,7 @@ snapshots:
       tarn: 3.0.2
     optionalDependencies:
       '@adonisjs/assembler': 7.8.2(typescript@5.9.3)
+      '@vinejs/vine': 4.2.0
       luxon: 3.7.2
     transitivePeerDependencies:
       - better-sqlite3
@@ -4097,9 +4140,9 @@ snapshots:
       - supports-color
       - tedious
 
-  '@adonisjs/presets@2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3)))':
+  '@adonisjs/presets@2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0))':
     dependencies:
-      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))
+      '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)
       '@poppinss/utils': 6.10.1
     optionalDependencies:
       '@adonisjs/assembler': 7.8.2(typescript@5.9.3)
@@ -4339,7 +4382,7 @@ snapshots:
   '@atproto/lexicon@0.6.0':
     dependencies:
       '@atproto/common-web': 0.4.7
-      '@atproto/syntax': 0.4.2
+      '@atproto/syntax': 0.4.3
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
       zod: 3.25.76
@@ -4391,6 +4434,10 @@ snapshots:
       zod: 3.25.76
 
   '@atproto/syntax@0.4.2': {}
+
+  '@atproto/syntax@0.4.3':
+    dependencies:
+      tslib: 2.8.1
 
   '@atproto/xrpc@0.7.7':
     dependencies:
@@ -5042,6 +5089,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.12': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stylistic/eslint-plugin@5.6.1(eslint@9.39.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2)
@@ -5163,6 +5212,8 @@ snapshots:
 
   '@types/qs@6.14.0': {}
 
+  '@types/validator@13.15.10': {}
+
   '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5253,6 +5304,21 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.50.0
       eslint-visitor-keys: 4.2.1
+
+  '@vinejs/compiler@4.1.2': {}
+
+  '@vinejs/vine@4.2.0':
+    dependencies:
+      '@poppinss/macroable': 1.1.0
+      '@poppinss/types': 1.2.1
+      '@standard-schema/spec': 1.1.0
+      '@types/validator': 13.15.10
+      '@vinejs/compiler': 4.1.2
+      camelcase: 9.0.0
+      dayjs: 1.11.19
+      dlv: 1.1.3
+      normalize-url: 8.1.1
+      validator: 13.15.26
 
   abort-controller@3.0.0:
     dependencies:
@@ -5445,6 +5511,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@8.0.0: {}
+
+  camelcase@9.0.0: {}
 
   caniuse-lite@1.0.30001761: {}
 
@@ -5676,6 +5744,8 @@ snapshots:
 
   date-fns@1.30.1: {}
 
+  dayjs@1.11.19: {}
+
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -5726,6 +5796,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dlv@1.1.3: {}
 
   dot-prop@9.0.0:
     dependencies:
@@ -6754,6 +6826,8 @@ snapshots:
       semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
+  normalize-url@8.1.1: {}
+
   np@10.2.0(@types/node@22.19.3)(typescript@5.9.3):
     dependencies:
       chalk: 5.6.2
@@ -7733,6 +7807,8 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@5.0.1: {}
+
+  validator@13.15.26: {}
 
   varint@6.0.0: {}
 

--- a/providers/oauth_provider.ts
+++ b/providers/oauth_provider.ts
@@ -4,6 +4,13 @@ import { OAuthSessionsModel, OAuthStatesModel, type OAuthProviderConfig } from '
 import { OAuthClient } from '../src/client.js'
 import { OAuthStore } from '../src/oauth_store.js'
 import { NodeSavedSession, NodeSavedState } from '@atproto/oauth-client-node'
+import type { VineAtproto } from '../src/vine/define.js'
+
+declare module '@vinejs/vine' {
+  interface Vine {
+    atproto: VineAtproto
+  }
+}
 
 declare module '@adonisjs/core/types' {
   export interface ContainerBindings {
@@ -14,6 +21,13 @@ declare module '@adonisjs/core/types' {
 
 export default class AtProtoProvider {
   constructor(protected app: ApplicationService) {}
+
+  async registerVinejs() {
+    if (this.app.usingVineJS) {
+      const { defineVineAtProto } = await import('../src/vine/define.js')
+      defineVineAtProto()
+    }
+  }
 
   register() {
     this.app.container.singleton('atproto.oauth.config', async () => {
@@ -61,6 +75,8 @@ export default class AtProtoProvider {
     if (this.app.getEnvironment() === 'web') {
       await client.configure(config.publicUrl, config.metadata, config.jwks)
     }
+
+    await this.registerVinejs()
   }
 
   async start() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,5 @@ export type OAuthStatesModel = LucidModel & {
 }
 
 export type OAuthModel = OAuthSessionsModel | OAuthStatesModel
+
+export type * from './vine/types.js'

--- a/src/vine/define.ts
+++ b/src/vine/define.ts
@@ -1,0 +1,32 @@
+import { Vine } from '@vinejs/vine'
+import {
+  VineAtprotoDatetime,
+  VineAtprotoDid,
+  VineAtprotoHandle,
+  VineAtprotoIdentifier,
+  VineAtprotoLanguage,
+  VineAtprotoService,
+  VineAtprotoAtUri,
+} from './schema.js'
+
+export type VineAtproto = {
+  identifier(): VineAtprotoIdentifier
+  did(): VineAtprotoDid
+  handle(): VineAtprotoHandle
+  service(): VineAtprotoService
+  atUri(): VineAtprotoAtUri
+  datetime(): VineAtprotoDatetime
+  language(): VineAtprotoLanguage
+}
+
+export function defineVineAtProto() {
+  Vine.getter('atproto', () => ({
+    identifier: () => new VineAtprotoIdentifier(),
+    did: () => new VineAtprotoDid(),
+    handle: () => new VineAtprotoHandle(),
+    service: () => new VineAtprotoService(),
+    atUri: () => new VineAtprotoAtUri(),
+    datetime: () => new VineAtprotoDatetime(),
+    language: () => new VineAtprotoLanguage(),
+  }))
+}

--- a/src/vine/rules.ts
+++ b/src/vine/rules.ts
@@ -1,0 +1,162 @@
+import {
+  isAtIdentifierString,
+  isAtUriString,
+  isDatetimeString,
+  isDidString,
+  isHandleString,
+  isLanguageString,
+} from '@atproto/lex'
+import { webUriSchema } from '@atproto/oauth-client-node'
+import vine from '@vinejs/vine'
+import { FieldContext } from '@vinejs/vine/types'
+
+function atString(value: unknown, field: FieldContext, rule: string) {
+  if (!field.isDefined) {
+    return false
+  }
+
+  if (typeof value === 'string') {
+    return true
+  }
+
+  field.report('The {{ field }} field value must be a string', rule, field)
+  return false
+}
+
+export const isAtUriRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-uri'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isAtUriString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol AT URI string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})
+
+export const isAtIdentifierRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-identifier'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isAtIdentifierString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol AT Identifier string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})
+
+export const isHandleRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-handle'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isHandleString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol handle string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})
+
+export const isDidRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-did'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isDidString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol DID string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})
+
+export const isServiceRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-service'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!URL.canParse(value as string)) {
+    field.report('The {{ field }} field value must be a valid URL string', ruleName, field)
+    return false
+  }
+
+  const { error, data } = webUriSchema.safeParse(value)
+  if (error) {
+    field.report('The {{ field }} field value must be a valid Web URI', ruleName, field, {
+      errors: error.flatten(),
+    })
+    return false
+  }
+
+  field.mutate(data, field)
+
+  return true
+})
+
+export const isDatetimeRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-datetime'
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isDatetimeString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol Datetime string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})
+
+export const isLanguageRule = vine.createRule((value, _, field) => {
+  const ruleName = 'at-language'
+
+  if (!atString(value, field, ruleName)) {
+    return false
+  }
+
+  if (!isLanguageString(value as string)) {
+    field.report(
+      'The {{ field }} field value must be a valid AT Protocol Language string',
+      ruleName,
+      field
+    )
+    return false
+  }
+
+  return true
+})

--- a/src/vine/schema.ts
+++ b/src/vine/schema.ts
@@ -1,0 +1,168 @@
+import {
+  AtIdentifierString,
+  AtUriString,
+  DatetimeString,
+  DidString,
+  HandleString,
+  isDatetimeString,
+  isLanguageString,
+  LanguageString,
+} from '@atproto/lex'
+import {
+  isAtIdentifierRule,
+  isAtUriRule,
+  isDatetimeRule,
+  isDidRule,
+  isHandleRule,
+  isLanguageRule,
+  isServiceRule,
+} from './rules.js'
+import { BaseLiteralType, symbols } from '@vinejs/vine'
+import { FieldOptions, Validation } from '@vinejs/vine/types'
+import { WebUri } from '@atproto/oauth-client-node'
+
+export class VineAtprotoAtUri extends BaseLiteralType<string, AtUriString, AtUriString> {
+  [symbols.SUBTYPE] = `atproto.at-uri`;
+  [symbols.UNIQUE_NAME] = `atproto.at-uri`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return typeof value === 'string' && value.toLowerCase().startsWith('at://')
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isAtUriRule()
+  }
+
+  clone() {
+    return new VineAtprotoAtUri(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoIdentifier extends BaseLiteralType<
+  string,
+  AtIdentifierString,
+  AtIdentifierString
+> {
+  [symbols.SUBTYPE] = `atproto.identifier`;
+  [symbols.UNIQUE_NAME] = `atproto.identifier`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return (
+      typeof value === 'string' &&
+      (value.toLocaleLowerCase().startsWith('did:') ||
+        (value.includes('.') && !value.startsWith('http:') && !value.startsWith('https:')))
+    )
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isAtIdentifierRule()
+  }
+
+  clone() {
+    return new VineAtprotoUri(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoDid extends BaseLiteralType<string, DidString, DidString> {
+  [symbols.SUBTYPE] = `atproto.did`;
+  [symbols.UNIQUE_NAME] = `atproto.did`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return typeof value === 'string' && value.toLocaleLowerCase().startsWith('did:')
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isDidRule()
+  }
+
+  clone() {
+    return new VineAtprotoDid(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoHandle extends BaseLiteralType<string, HandleString, HandleString> {
+  [symbols.SUBTYPE] = `atproto.handle`;
+  [symbols.UNIQUE_NAME] = `atproto.handle`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return (
+      typeof value === 'string' &&
+      value.includes('.') &&
+      !value.startsWith('http:') &&
+      !value.startsWith('https:')
+    )
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isHandleRule()
+  }
+
+  clone() {
+    return new VineAtprotoHandle(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoService extends BaseLiteralType<string, WebUri, WebUri> {
+  [symbols.SUBTYPE] = `atproto.service`;
+  [symbols.UNIQUE_NAME] = `atproto.service`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return typeof value === 'string' && URL.canParse(value)
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isServiceRule()
+  }
+
+  clone() {
+    return new VineAtprotoService(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoDatetime extends BaseLiteralType<string, DatetimeString, DatetimeString> {
+  [symbols.SUBTYPE] = `atproto.datetime`;
+  [symbols.UNIQUE_NAME] = `atproto.datetime`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return typeof value === 'string' && isDatetimeString(value)
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isDatetimeRule()
+  }
+
+  clone() {
+    return new VineAtprotoDatetime(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}
+
+export class VineAtprotoLanguage extends BaseLiteralType<string, LanguageString, LanguageString> {
+  [symbols.SUBTYPE] = `atproto.language`;
+  [symbols.UNIQUE_NAME] = `atproto.language`;
+
+  // Required for unionOfTypes
+  [symbols.IS_OF_TYPE] = (value: unknown) => {
+    return typeof value === 'string' && isLanguageString(value)
+  }
+
+  constructor(options?: FieldOptions, validations?: Validation<any>[]) {
+    super(options, validations || [])
+    this.dataTypeValidator = isLanguageRule()
+  }
+
+  clone() {
+    return new VineAtprotoLanguage(this.cloneOptions(), this.cloneValidations()) as this
+  }
+}

--- a/src/vine/types.ts
+++ b/src/vine/types.ts
@@ -1,0 +1,8 @@
+export type {
+  AtIdentifierString,
+  AtUriString,
+  DatetimeString,
+  DidString,
+  HandleString,
+  LanguageString,
+} from '@atproto/lex'

--- a/stubs/validators/oauth_validator.stub
+++ b/stubs/validators/oauth_validator.stub
@@ -3,33 +3,10 @@
 }}}
 import vine from '@vinejs/vine'
 
-export const loginRequestValidator = vine.compile(
-  vine.object({
-    input: vine.string(),
-  })
-)
+export const loginRequestValidator = vine.create({
+  input: vine.unionOfTypes([vine.atproto.handle(), vine.atproto.did(), vine.atproto.service()]),
+})
 
-export const signupRequestValidator = vine.compile(
-  vine.object({
-    input: vine
-      .string()
-      .url({
-        protocols: ['https'],
-        require_host: true,
-        require_tld: true,
-        require_protocol: false,
-        allow_query_components: false,
-        allow_fragments: false,
-        disallow_auth: true,
-      })
-      .normalizeUrl({
-        defaultProtocol: 'https',
-        stripHash: true,
-        removeQueryParameters: true,
-        removeSingleSlash: true,
-        removeTrailingSlash: true,
-        removePath: true,
-      })
-      .optional(),
-  })
-)
+export const signupRequestValidator = vine.create({
+  input: vine.atproto.service().optional(),
+})


### PR DESCRIPTION
Implementation of custom vine.js rules for validating various AT Protocol [string format](https://atproto.com/specs/lexicon#string-formats):

- `vine.atproto.identifier()`
- `vine.atproto.did()`
- `vine.atproto.handle()`
- `vine.atproto.service()`
- `vine.atproto.atUri()`
- `vine.atproto.datetime()`
- `vine.atproto.language()`

The only rule that isn't a typical [string format](https://atproto.com/specs/lexicon#string-formats) from AT Protocol is `vine.atproto.service()` which is used for validating OAuth service identifiers, which are essentially just URLs without an components after the hostname. You'd use this rule for validating an OAuth sign up request.