### PR TITLE
Rename to @adonisjs-atproto/oauth and set up staged publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "thisismissem/adonisjs-atproto-oauth" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "adonisjs-atproto/oauth" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/rename-to-adonisjs-atproto-scope.md
+++ b/.changeset/rename-to-adonisjs-atproto-scope.md
@@ -1,0 +1,10 @@
+---
+'@adonisjs-atproto/oauth': major
+---
+
+Rename the package to the `@adonisjs-atproto` org scope: `@thisismissem/adonisjs-atproto-oauth` is now published as `@adonisjs-atproto/oauth`.
+
+This is a breaking change. To upgrade:
+
+- Replace the dependency `@thisismissem/adonisjs-atproto-oauth` with `@adonisjs-atproto/oauth` in your `package.json`.
+- Update all imports, including subpath imports such as `@adonisjs-atproto/oauth/auth/provider` and the `@adonisjs-atproto/oauth/provider` provider registration in `adonisrc.ts`.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,15 +5,19 @@ on:
   - pull_request
   - workflow_call
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.node-version'
           cache: pnpm
@@ -26,12 +30,14 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.node-version'
           cache: pnpm
@@ -44,16 +50,18 @@ jobs:
 
   tests:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'ThisIsMissEm' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'adonisjs-atproto' }}
     permissions:
       id-token: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   release:
     name: Release
@@ -20,27 +22,26 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.node-version'
           cache: pnpm
 
-      # Found this via https://github.com/tinacms/tinacms/pull/6249/files
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Enable staged-publishing shim
+        run: echo "$GITHUB_WORKSPACE/scripts/changesets-staged-publishing" >> "$GITHUB_PATH"
+
       - name: Create Release Pull Request or Publish to pnpm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
 
         with:
           title: Prepare release

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,5 @@
+build
+node_modules
+coverage
+tmp
 pnpm-lock.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @thisismissem/adonisjs-atproto-oauth
+# @adonisjs-atproto/oauth
 
 ## 3.0.4
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following packages should already be installed and configured in your projec
 ## Installation
 
 ```sh
-node ace add @thisismissem/adonisjs-atproto-oauth
+node ace add @adonisjs-atproto/oauth
 ```
 
 ### Configuring
@@ -21,7 +21,7 @@ node ace add @thisismissem/adonisjs-atproto-oauth
 If you didn't use `node ace add` you can later run the configuration using:
 
 ```sh
-node ace configure @thisismissem/adonisjs-atproto-oauth
+node ace configure @adonisjs-atproto/oauth
 ```
 
 ### Next steps
@@ -48,7 +48,7 @@ To use `atprotoAuthProvider`, we need to update the `@adonisjs/auth` configurati
 import { defineConfig } from '@adonisjs/auth'
 - import { sessionGuard, sessionUserProvider } from '@adonisjs/auth/session'
 + import { sessionGuard } from '@adonisjs/auth/session'
-+ import { atprotoAuthProvider } from '@thisismissem/adonisjs-atproto-oauth/auth/provider'
++ import { atprotoAuthProvider } from '@adonisjs-atproto/oauth/auth/provider'
 
 const authConfig = defineConfig({
   default: 'web',
@@ -105,7 +105,7 @@ For example, if we wanted to add a method for fetching the users' profile from B
 
 ```ts
 // src/extensions.ts
-import { AtProtoUser } from '@thisismissem/adonisjs-atproto-oauth'
+import { AtProtoUser } from '@adonisjs-atproto/oauth'
 import * as lexicon from '#lexicons/index'
 
 AtProtoUser.macro('fetchProfile', async function hasProfile(this: AtProtoUser) {
@@ -118,7 +118,7 @@ AtProtoUser.macro('fetchProfile', async function hasProfile(this: AtProtoUser) {
   return undefined
 })
 
-declare module '@thisismissem/adonisjs-atproto-oauth' {
+declare module '@adonisjs-atproto/oauth' {
   interface AtProtoUser {
     fetchProfile(): Promise<undefined | lexicon.app.bsky.actor.profile.Main>
   }
@@ -142,7 +142,7 @@ export default class ExampleController {
 
 In the generated `app/controllers/oauth_controller.ts` file you'll notice that we have a `oauth` property on `HttpContext`. This is a lightweight wrapper around the `NodeOAuthClient` from `@atproto/oauth-client-node` which has methods integrated with Adonis.js
 
-You can see the full methods provide in [`OAuthContext`](https://github.com/ThisIsMissEm/adonisjs-atproto-oauth/blob/main/src/oauth_context.ts)
+You can see the full methods provide in [`OAuthContext`](https://github.com/adonisjs-atproto/oauth/blob/main/src/oauth_context.ts)
 
 ## Vine.js Validators
 

--- a/configure.ts
+++ b/configure.ts
@@ -20,7 +20,7 @@ import { stubsRoot } from './stubs/main.ts'
 type Packages = { name: string; isDevDependency: boolean }[]
 
 export async function configure(command: Configure) {
-  const packageName = '@thisismissem/adonisjs-atproto-oauth'
+  const packageName = '@adonisjs-atproto/oauth'
 
   const inertiaConfigPath = command.app.configPath('inertia.ts')
   const usingInertia = existsSync(inertiaConfigPath)
@@ -61,7 +61,7 @@ export async function configure(command: Configure) {
 
   // Add provider to rc file
   await codemods.updateRcFile((rcFile) => {
-    rcFile.addProvider('@thisismissem/adonisjs-atproto-oauth/provider')
+    rcFile.addProvider('@adonisjs-atproto/oauth/provider')
   })
 
   // Add migrations:
@@ -160,7 +160,7 @@ export async function configure(command: Configure) {
 }
 
 async function modifyAuthConfig(command: Configure, project: CodeTransformer['project']) {
-  const atprotoAuthProvider = '@thisismissem/adonisjs-atproto-oauth/auth/provider'
+  const atprotoAuthProvider = '@adonisjs-atproto/oauth/auth/provider'
   const authConfigPath = command.app.configPath('auth.ts')
   const action = command.logger.action(`update config/auth.ts`)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@thisismissem/adonisjs-atproto-oauth",
+  "name": "@adonisjs-atproto/oauth",
   "description": "Adonis.js provider for doing AT Protocol OAuth logins",
   "version": "3.0.4",
   "engines": {
@@ -57,7 +57,7 @@
     }
   ],
   "repository": {
-    "url": "https://github.com/ThisIsMissEm/adonisjs-atproto-oauth"
+    "url": "https://github.com/adonisjs-atproto/oauth"
   },
   "dependencies": {
     "@poppinss/macroable": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
+  "packageManager": "pnpm@11.15.1",
   "type": "module",
   "files": [
     "build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@swc/core': true
+  core-js: true

--- a/scripts/changesets-staged-publishing/pnpm
+++ b/scripts/changesets-staged-publishing/pnpm
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Rewrites `pnpm publish ...` -> `pnpm stage publish ...`; forwards everything
+# else to the real pnpm. Workaround for changesets#2025 / pnpm#13183.
+set -euo pipefail
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REAL_PNPM="$(PATH="${PATH//$SELF_DIR:/}" command -v pnpm)"
+if [ "${1:-}" = "publish" ]; then
+  shift
+  exec "$REAL_PNPM" stage publish "$@"
+fi
+exec "$REAL_PNPM" "$@"

--- a/stubs/config/atproto_oauth.stub
+++ b/stubs/config/atproto_oauth.stub
@@ -7,9 +7,9 @@ import {
   defineConfig,
   lucidSessionStore,
   lucidStateStore,
-} from '@thisismissem/adonisjs-atproto-oauth'
+} from '@adonisjs-atproto/oauth'
 {{#else}}
-import { defineConfig } from '@thisismissem/adonisjs-atproto-oauth'
+import { defineConfig } from '@adonisjs-atproto/oauth'
 {{/if}}
 import env from '#start/env'
 


### PR DESCRIPTION
Two related changes to move this package onto the shared org scope and modernise how it publishes.

## 1. Rename to `@adonisjs-atproto/oauth` (breaking)

Moves the package from the personal `@thisismissem` scope to the shared `@adonisjs-atproto` org scope, dropping the redundant `adonisjs-atproto-` basename prefix. Unlike the labeler (which was never published), this package **is** published, so this is a breaking change:

- A `major` changeset drives the first new-scope release to **4.0.0**.
- Existing CHANGELOG history is preserved (H1 retitled only); old GitHub URLs 301-redirect after the org move.
- Consumers must swap the dependency and update imports (including subpaths like `@adonisjs-atproto/oauth/auth/provider`).

## 2. Staged publishing + workflow hardening

- **Staged publishing:** a PATH shim rewrites `pnpm publish` → `pnpm stage publish` (changesets/pnpm have no native staged-publish config). Releases land in npm staging, hidden from installs until approved via `pnpm stage approve <id>` (human 2FA).
- **pnpm 11.15.1:** required for `pnpm stage publish`; build-script approvals recorded in `pnpm-workspace.yaml`. Obsolete npm-upgrade step removed.
- **Hardening:** default-deny top-level `permissions: {}` with least-privilege per-job grants; all actions SHA-pinned (`actions/*` bumped to latest; `pnpm/action-setup` and `changesets/action` pinned, allowlisted via org wildcard entries).

`package.json` and `release.yml` are hunk-split so each concern is its own commit.

Verified: `pnpm typecheck` (exit 0), `pnpm format:check` (clean aside from the gitignored local `.claude/settings.local.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
